### PR TITLE
Multi-file support for EPOCH SDF files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contribution Guide
+
+We welcome any and all contributions to `xr-tui`! Whether it's reporting issues, suggesting features, improving the documentation, or submitting pull requests, your input helps improve this tool for the community.
+
+## Adding Multi-File Support for your Data Format
+
+To keep `xr-tui` agnostic of specific data formats, multi-file loading is handled via **Custom Backends**. If you want to add support for a specific file grouping (e.g., `*.sdf`), you must create a plugin that implements the `open_mfdatatree` method.
+
+### Architecture
+
+When multiple files are passed to the CLI, `xr-tui` looks for an entry point matching the file extension. It then delegates the loading process to that plugin.
+
+### Implementation Steps
+
+#### A. Define the Entry Point
+
+In your plugin's `pyproject.toml`, register your backend under the `xr_tui.backends` group. The name should match the file glob you want to support.
+
+```toml
+[project.entry-points."xr_tui.backends"]
+"*.sdf" = "your_package.module:XrTUIEndpoint"
+```
+
+#### B. Create the Endpoint Class
+
+Your plugin must provide a class with an `open_mfdatatree` method. This method is responsible for returning a valid `xarray.DataTree`.
+
+```python
+import xarray as xr
+from pathlib import Path
+
+class XrTUIEndpoint:
+    @staticmethod
+    def open_mfdatatree(tui_instance, paths: list[Path]) -> xr.DataTree:
+        # Implement your custom concatenation logic here
+        # Example: return xr.open_mfdataset(paths).to_datatree()
+        return your_custom_loading_logic(paths)
+```
+
+### Requirements for Support
+- All files in a multi-file load must share the same **directory** and **extension**.
+- The plugin must be installed in the same environment as `xr-tui`.
+
+### How to test locally
+
+If you are developing a plugin, you can install it into your `xr-tui` environment to test the entry point:
+
+```bash
+pipx inject xr-tui ./path/to/your/plugin
+# Or with uv
+uv tool install xr-tui --with ./path/to/your/plugin
+```

--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ uv tool install xr-tui
 To start xr-tui, simply run the following command in your terminal:
 
 ```bash
-xr data.nc
+xr <filename>
 ```
 
-This will launch the TUI, allowing you to explore the contents of `data.nc`.
+This will launch the TUI, allowing you to explore the contents of `filename`.
 
 
 You can also specify a particular group within a file to load:
 
 ```bash
-xr data.nc --group summary
+xr <filename> --group summary
 ```
 
 xr-tui also works with remote datasets accessible via HTTP:

--- a/README.md
+++ b/README.md
@@ -9,17 +9,21 @@
 ![PyPI - Status](https://img.shields.io/pypi/v/xr-tui)
 
 
-xr-tui is an interactive terminal user interface (TUI) for exploring and visualizing multi-dimensional datasets. It uses xarray to support loading NetCDF, Zarr, HDF5 and [EPOCH SDF](https://epochpic.github.io/) tree structures, and provides a user-friendly interface for data exploration directly in the terminal.
+xr-tui is an interactive terminal user interface (TUI) for exploring and visualizing multi-dimensional datasets. It uses xarray to support loading NetCDF, Zarr and HDF5 tree structures, and provides a user-friendly interface for data exploration directly in the terminal.
 
 ![](demo.gif)
 
 ## Features
-- Interactive navigation through NetCDF, Zarr, [NeXus](https://www.nexusformat.org/), HDF5 and [EPOCH SDF](https://epochpic.github.io/) datasets.
+- Interactive navigation through NetCDF, Zarr, and HDF5 datasets.
 - Visualization of 1D and 2D data using plotext for terminal-based plotting.
 - Support for slicing multi-dimensional data.
 - Easy-to-use command-line interface.
 - Displays dataset statistics and metadata.
 - Handles HDF5 files not formatted as xarray datasets.
+
+## Domain Specific Formats
+xr-tui additionally supports domain specific formats such as the HDF5 [NeXus](https://www.nexusformat.org/) format along with any custom xarray backends that supports datatrees. The list of actively supported xarray backends is as follows:
+- [sdf-xarray](https://sdf-xarray.readthedocs.io/en/latest/index.html) -  Used for loading the Particle-in-Cell code [EPOCH](https://epochpic.github.io/)'s output files.
 
 ## Installation
 You can install xr-tui via pip:
@@ -34,10 +38,6 @@ Or as a uv tool:
 uv tool install xr-tui
 ```
 
-
-If you wish to use this with [EPOCH SDF](https://epochpic.github.io/) files,
-please consult the [sdf-xarray documentation #visualisation-on-hpcs](https://sdf-xarray.readthedocs.io/en/stable/key_functionality.html#visualisation-on-hpcs)
-
 ## Usage
 To start xr-tui, simply run the following command in your terminal:
 
@@ -47,7 +47,6 @@ xr data.nc
 
 This will launch the TUI, allowing you to explore the contents of `data.nc`.
 
-xr-tui supports various file formats compatible with xarray, including NetCDF, Zarr, HDF5 and EPOCH SDF.
 
 You can also specify a particular group within a file to load:
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 ![PyPI - Status](https://img.shields.io/pypi/v/xr-tui)
 
 
-xr-tui is an interactive terminal user interface (TUI) for exploring and visualizing multi-dimensional datasets. It uses xarray to support loading NetCDF, Zarr, and HDF5 tree structures, and provides a user-friendly interface for data exploration directly in the terminal.
+xr-tui is an interactive terminal user interface (TUI) for exploring and visualizing multi-dimensional datasets. It uses xarray to support loading NetCDF, Zarr, HDF5 and [EPOCH SDF](https://epochpic.github.io/) tree structures, and provides a user-friendly interface for data exploration directly in the terminal.
 
 ![](demo.gif)
 
 ## Features
-- Interactive navigation through NetCDF, Zarr, [NeXus](https://www.nexusformat.org/) and HDF5 datasets.
+- Interactive navigation through NetCDF, Zarr, [NeXus](https://www.nexusformat.org/), HDF5 and [EPOCH SDF](https://epochpic.github.io/) datasets.
 - Visualization of 1D and 2D data using plotext for terminal-based plotting.
 - Support for slicing multi-dimensional data.
 - Easy-to-use command-line interface.
@@ -34,6 +34,10 @@ Or as a uv tool:
 uv tool install xr-tui
 ```
 
+
+If you wish to use this with [EPOCH SDF](https://epochpic.github.io/) files,
+please consult the [sdf-xarray documentation #visualisation-on-hpcs](https://sdf-xarray.readthedocs.io/en/stable/key_functionality.html#visualisation-on-hpcs)
+
 ## Usage
 To start xr-tui, simply run the following command in your terminal:
 
@@ -43,7 +47,7 @@ xr data.nc
 
 This will launch the TUI, allowing you to explore the contents of `data.nc`.
 
-xr-tui supports various file formats compatible with xarray, including NetCDF, Zarr, and HDF5.
+xr-tui supports various file formats compatible with xarray, including NetCDF, Zarr, HDF5 and EPOCH SDF.
 
 You can also specify a particular group within a file to load:
 
@@ -56,7 +60,6 @@ xr-tui also works with remote datasets accessible via HTTP:
 ```bash
 xr http://example.com/data.zarr
 ```
-
 
 ## Key Command Reference
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,30 +3,31 @@ name = "xr-tui"
 version = "2025.1.0"
 requires-python = ">=3.11"
 description = "A Textual User Interface (TUI) for exploring xarray Datasets."
-license = {text = "MIT"}
+license = { text = "MIT" }
 
 authors = [
-  {name = "Samuel Jackson", email = "samuel.jackson@outlook.com"}
+  { name = "Samuel Jackson", email = "samuel.jackson@outlook.com" },
+  { name = "Joel Adams", email = "joel.adams@york.ac.uk" },
 ]
 
 maintainers = [
-  {name = "Samuel Jackson", email = "samuel.jackson@outlook.com"}
+  { name = "Samuel Jackson", email = "samuel.jackson@outlook.com" },
 ]
 
 readme = "README.md"
 classifiers = [
   "Development Status :: 4 - Beta",
-  "Programming Language :: Python"
+  "Programming Language :: Python",
 ]
 
 dependencies = [
-    "fsspec[s3]>=2025.10.0",
-    "scipy>=1.13.1",
-    "textual>=6.7.1",
-    "textual-plotext>=1.0.1",
-    "textual-slider>=0.2.0",
-    "xarray[io]>=2024.7.0",
-    "zarr>=2.18.2",
+  "fsspec[s3]>=2025.10.0",
+  "scipy>=1.13.1",
+  "textual>=6.7.1",
+  "textual-plotext>=1.0.1",
+  "textual-slider>=0.2.0",
+  "xarray[io]>=2024.7.0",
+  "zarr>=2.18.2",
 ]
 
 [tool.setuptools.packages.find]
@@ -41,10 +42,10 @@ exclude = [".venv"]
 
 [dependency-groups]
 dev = [
-    "bump-my-version>=1.2.4",
-    "pylint>=3.3.9",
-    "ruff>=0.14.8",
-    "textual-dev>=1.8.0",
+  "bump-my-version>=1.2.4",
+  "pylint>=3.3.9",
+  "ruff>=0.14.8",
+  "textual-dev>=1.8.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,28 +6,28 @@ description = "A Textual User Interface (TUI) for exploring xarray Datasets."
 license = { text = "MIT" }
 
 authors = [
-  { name = "Samuel Jackson", email = "samuel.jackson@outlook.com" },
-  { name = "Joel Adams", email = "joel.adams@york.ac.uk" },
+    { name = "Samuel Jackson", email = "samuel.jackson@outlook.com" },
+    { name = "Joel Adams", email = "joel.adams@york.ac.uk" },
 ]
 
 maintainers = [
-  { name = "Samuel Jackson", email = "samuel.jackson@outlook.com" },
+    { name = "Samuel Jackson", email = "samuel.jackson@outlook.com" },
 ]
 
 readme = "README.md"
 classifiers = [
-  "Development Status :: 4 - Beta",
-  "Programming Language :: Python",
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python",
 ]
 
 dependencies = [
-  "fsspec[s3]>=2025.10.0",
-  "scipy>=1.13.1",
-  "textual>=6.7.1",
-  "textual-plotext>=1.0.1",
-  "textual-slider>=0.2.0",
-  "xarray[io]>=2024.7.0",
-  "zarr>=2.18.2",
+    "fsspec[s3]>=2025.10.0",
+    "scipy>=1.13.1",
+    "textual>=6.7.1",
+    "textual-plotext>=1.0.1",
+    "textual-slider>=0.2.0",
+    "xarray[io]>=2024.7.0",
+    "zarr>=2.18.2",
 ]
 
 [tool.setuptools.packages.find]
@@ -42,11 +42,11 @@ exclude = [".venv"]
 
 [dependency-groups]
 dev = [
-  "bump-my-version>=1.2.4",
-  "pylint>=3.3.9",
-  "ruff>=0.14.8",
-  "textual-dev>=1.8.0",
-  "ty>=0.0.12",
+    "bump-my-version>=1.2.4",
+    "pylint>=3.3.9",
+    "ruff>=0.14.8",
+    "textual-dev>=1.8.0",
+    "ty>=0.0.12",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ xr_tui = ["*.tcss"]
 [tool.ruff]
 exclude = [".venv"]
 
+[tool.pylint.design]
+max-attributes = 10
+
 [dependency-groups]
 dev = [
     "bump-my-version>=1.2.4",

--- a/xr_tui/cli.py
+++ b/xr_tui/cli.py
@@ -151,8 +151,7 @@ class XarrayTUI(App):
         self.title = "xr-tui"
         self.theme = "monokai"
         self.group = group
-        print(path_list)
-        print(type(path_list))
+
         self.paths = [Path(p).resolve() for p in path_list]
 
         if len(self.paths) == 1:

--- a/xr_tui/cli.py
+++ b/xr_tui/cli.py
@@ -196,7 +196,7 @@ class XarrayTUI(App):
 
         self.file_glob = f"*{file_suffixes[0]}"
         self.file = f"{parent_dirs[0]}/{self.file_glob}"
-        self.file_info = [self._get_file_info(path) for path in paths]
+        self.file_info = [self._get_file_info(str(path)) for path in paths]
 
         if self.file_glob.lower() == "*.sdf":
             import sdf_xarray as sdfxr

--- a/xr_tui/cli.py
+++ b/xr_tui/cli.py
@@ -161,7 +161,7 @@ class XarrayTUI(App):
 
     def _init_single_file(self, path: Path) -> None:
         """Load single file xarray or HDF5 datatree"""
-        self.file = str(path)
+        self.file = str(Path(path).resolve())
         self.file_info = self._get_file_info(self.file)
 
         try:


### PR DESCRIPTION
Hello Sam,

I hope you are ok with receiving PRs to this repository! I came across this project the other week and was surprised to see that you'd had the same idea just a few weeks before me. Loving the lightweight TUI so far and it was nice to see it working out of the box.

I was considering implementing a similar system for my custom `xarray` backend which is built for reading in the output files (called SDF files) for the Particle-in-Cell code EPOCH. This is an international code that is are widely used in laser-plasma and ultra-high intensity physics. The package that I maintain with this custom backend is called [`sdf-xarray`](https://github.com/epochpic/sdf-xarray) and with a bit of tweaking I have implemented `xarray.DataTree` support as seen in https://github.com/epochpic/sdf-xarray/pull/89. 

One of the caveats of my backend is that the files that the simulation code produces are output at a time interval specified by the user so `sdf-xarray` has a custom function that reads the metadata produced by each file and stitches them all together into one big `xarray.Dataset` with a `time` dimension as seen with `xarray.open_mfdataset`. Unfortunately `xr-tui` doesn't support this feature which makes sense since `xarray` doesn't seem to have an implementation for `open_mfdatatree` (which is quite strange...). As a result I have made some tweaks to your project so that it can support opening multiple files passed in as a list

```bash
xr path/to/simulation/*.sdf # the terminal resolves this automatically to a complete list of paths that match the glob
```

On top of that I have made some minor changes to the `File Information` section so that it displays a summary of all file information if a glob is passed in along with individual information of each file.
<img width="818" height="649" alt="image" src="https://github.com/user-attachments/assets/883f96c2-f144-439a-997b-102de5f2db0e" />

## Testing with SDF files
Test and documentation files for `sdf-xarray` are stored on Zenodo and can be accessed here https://doi.org/10.5281/zenodo.17991042 I'd recommend utilising the `tutorial_dataset_xd` datasets as they are realistic whereas the test ones are not. 

## TLDR of changes made

Note: If you wish to test this yourself you'll need to be using https://github.com/epochpic/sdf-xarray/pull/89 to visualise EPOCH SDF files.

- Modified the parser to always parse a list of strings
- If one item is passed in then its absolute path is resolved and the process continues as before
- If many items are passed in then each is resolved
  1.  `self.file` is the original glob (e.g. `path/to/simulation/*.sdf`)
  2. `self.file_info` is now a list of each files information using the same function as before
  3. `self.glob` a new variable that points to the glob (e.g. `*.sdf`)
  4. If the glob is of type `*.sdf` then the package is loaded in and `sdf_xarray.open_mfdatatree` is called
  5. If the glob is not that then raise `NotImplementedError`
- In the building of the file info Tree decide whether to display the single file info or summary depending upon if `self.glob` exists
- Refactored to a function `_add_leaf_items` the for loop of adding dictionaries to leaves of a node