### PR TITLE
Add global attributes

### DIFF
--- a/xr_tui/cli.py
+++ b/xr_tui/cli.py
@@ -263,7 +263,7 @@ class XarrayTUI(App):
         # NOTE This is hardcoded to find the second node which should be the
         # "Root" node. It may need changing if the above code changes node ordering
         attributes_node = tree.root.children[1].add(
-            f"Attributes ([blue]{num_attributes}[/blue])"
+            f"Attributes ([blue]{num_attributes}[/blue])", before=0
         )
         self._add_attributes_node(attributes_node, self.dataset.attrs)
 


### PR DESCRIPTION
Add the global attributes (from `dataset.attrs`) to a sub node titled `Attributes (num_attrs)` under the `File Information` node.

This is recursive as the attributes might contain sub `dict`s. This is the case in `sdf-xarray` as we add the simulation setup file to the attributes as a dictionary.