### PR TITLE
Refactor linter to use only ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,40 +3,30 @@ name: Lint
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**.py'
   pull_request:
     branches: [ main ]
+    paths:
+      - '**.py'
 
 jobs:
-  ruff:
+  lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    
-    - name: Install ruff
-      run: pip install ruff>=0.14.8
-    
-    - name: Run ruff
-      run: ruff check .
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  pylint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    
-    - name: Install dependencies
-      run: |
-        pip install pylint>=3.3.9
-        pip install -e .
-    
-    - name: Run pylint
-      run: pylint xr_tui
+      # Providing 'args' prevents the action from running 'ruff check .'
+      # immediately after installing ruff.
+      - name: Install Ruff
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "--version"
+
+      - name: Check
+        run: ruff check --output-format=github src tests
+
+      - name: Format
+        run: ruff format --check --diff src tests

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![GitHubIssues](https://img.shields.io/badge/issue_tracking-github-blue.svg)](https://github.com/samueljackson92/xr-tui/issues)
 [![GitTutorial](https://img.shields.io/badge/PR-Welcome-%23FF8300.svg?)](https://github.com/samueljackson92/xr-tui/pulls)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![linting: pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
 ![PyPI - Status](https://img.shields.io/pypi/v/xr-tui)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,6 @@ xr_tui = ["*.tcss"]
 [tool.ruff]
 exclude = [".venv"]
 
-[tool.pylint.design]
-max-attributes = 10
-
 [dependency-groups]
 dev = [
     "bump-my-version>=1.2.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,20 +3,18 @@ name = "xr-tui"
 version = "0.1.0"
 requires-python = ">=3.11"
 description = "A Textual User Interface (TUI) for exploring xarray Datasets."
-license = {text = "MIT"}
+license = { text = "MIT" }
 
-authors = [
-  {name = "Samuel Jackson", email = "samuel.jackson@outlook.com"}
-]
+authors = [{ name = "Samuel Jackson", email = "samuel.jackson@outlook.com" }]
 
 maintainers = [
-  {name = "Samuel Jackson", email = "samuel.jackson@outlook.com"}
+    { name = "Samuel Jackson", email = "samuel.jackson@outlook.com" },
 ]
 
 readme = "README.md"
 classifiers = [
-  "Development Status :: 4 - Beta",
-  "Programming Language :: Python"
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python",
 ]
 
 dependencies = [
@@ -43,7 +41,6 @@ exclude = [".venv"]
 [dependency-groups]
 dev = [
     "bump-my-version>=1.2.4",
-    "pylint>=3.3.9",
     "ruff>=0.14.8",
     "textual-dev>=1.8.0",
     "ty>=0.0.12",


### PR DESCRIPTION
Refactor linter to use only ruff which removes the requirement for `pylint`

Note: If merged prior to #4 we need to update and remove the `[tool.pylint.design]` block from `pyporject.toml`.