### PR TITLE
Add table view accessible via t keybinding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Project Is
+
+**xr-tui** is a Python TUI (terminal user interface) for interactively exploring multi-dimensional scientific datasets (NetCDF, Zarr, HDF5). Users navigate a tree of variables/groups, view statistics, and generate plots — all in the terminal. Built on [Textual](https://textual.textualize.io/) with xarray as the data backend.
+
+## Commands
+
+```bash
+# Lint (matches CI)
+ruff check .
+pylint xr_tui
+
+# Run the app locally
+xr <path-to-dataset>          # local file
+xr <path> --group <group>     # open a specific HDF5/NetCDF group
+xr http://example.com/data.zarr  # remote file via HTTP/S3
+
+# Install in development mode
+uv sync
+uv run xr <file>
+```
+
+There is no test suite — quality assurance relies entirely on `ruff` and `pylint`.
+
+## Architecture
+
+The package lives in `xr_tui/` and has three modules:
+
+### `cli.py` — Application core
+- **`XarrayTUI`** is the main `textual.App` subclass. It handles file loading, dataset tree construction, keybindings, and screen navigation.
+- **`PlotScreen`** and **`StatisticsScreen`** are modal screens pushed onto the screen stack for secondary views.
+- On launch, the app reads the file using xarray/h5py, builds a `DataTree`, then populates a `Tree` widget where each node's `.data` dict carries `{"name": ..., "type": "variable_node"|"group_node", "item": xr.DataArray|xr.Dataset}`.
+- Multi-file loading uses the `xr_tui.backends` entry-point group — third-party packages can register backends that combine files into a single `DataTree`.
+
+### `plotting.py` — Plot widgets
+Four widget classes, selected based on variable dimensionality:
+- **`ErrorWidget`**: unsupported types
+- **`Plot1DWidget`**: line plots
+- **`Plot2DWidget`**: matrix/heatmap
+- **`PlotNDWidget`**: interactive N-D slicing — radio buttons choose X/Y axes, sliders slice the remaining dimensions, and plots update reactively
+
+### `hdf_reader.py` — HDF5 adapter
+- `hdf5_to_datatree()` converts arbitrary HDF5 files (not written as xarray datasets) into `DataTree` structures that the rest of the app can consume uniformly.
+- Handles HDF5 object and region references, and infers dimension names from group structure.
+
+### `xr-tui.tcss` — Textual CSS
+Styling for modal screens and plot containers. Grid-based layouts; edit this when changing widget layout or colors.
+
+## Key Conventions
+
+- **Keybindings**: Vim-style (`j`/`k` up/down, `h`/`l` collapse/expand). Declared in the `BINDINGS` tuple of `XarrayTUI`.
+- **Node metadata**: Tree node `.data` dicts are the contract between `cli.py` and `plotting.py`/statistics logic — always include `type` and `item` keys.
+- **Dependency management**: Use `uv`. The `uv.lock` file is committed and should stay in sync.
+- **Versioning**: Managed by `bump-my-version` (`.bumpversion.toml`). Do not manually edit version strings; use `bump-my-version bump <part>`.
+- **CI**: `.github/workflows/lint.yml` runs `ruff check .` and `pylint xr_tui` on every push/PR to `main`. Both must pass before merging.

--- a/uv.lock
+++ b/uv.lock
@@ -2223,7 +2223,7 @@ io = [
 
 [[package]]
 name = "xr-tui"
-version = "2025.2.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fsspec", extra = ["s3"] },

--- a/xr_tui/cli.py
+++ b/xr_tui/cli.py
@@ -19,7 +19,7 @@ from textual.widgets import DataTable, Footer, Header, Tree
 from textual_plotext import PlotextPlot
 
 from xr_tui.hdf_reader import hdf5_to_datatree
-from xr_tui.plotting import ErrorWidget, Plot1DWidget, Plot2DWidget, PlotNDWidget
+from xr_tui.plotting import ErrorWidget, Plot1DWidget, Plot2DWidget, PlotNDWidget, TableNDWidget
 
 mp.set_start_method("fork")
 
@@ -139,6 +139,26 @@ class PlotScreen(Screen):
         yield plot_widget
 
 
+class TableScreen(Screen):
+    """A screen to display a variable's values as a navigable table."""
+
+    BINDINGS = [("escape", "app.pop_screen", "Pop screen")]
+
+    def __init__(self, variable: xr.DataArray, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.variable = variable
+
+    def compose(self) -> ComposeResult:
+        """Create child widgets for the screen."""
+        if self.variable.ndim == 0:
+            widget = ErrorWidget(self.variable, id="table-screen-error")
+        else:
+            widget = TableNDWidget(self.variable, id="table-screen")
+        widget.border_title = f"[white]Table of {self.variable.name}[/]"
+        widget.border_subtitle = "[white]Press 'Esc' to return[/]"
+        yield widget
+
+
 class XarrayTUI(App):
     """A Textual app to view xarray Datasets."""
 
@@ -152,6 +172,7 @@ class XarrayTUI(App):
         ("c", "collapse_all", "Collapse all nodes"),
         ("p", "plot_variable", "Plot variable"),
         ("s", "show_statistics", "Show statistics"),
+        ("t", "show_table", "Show table"),
         ("d", "toggle_dark", "Toggle dark mode"),
         ("j", "cursor_down", "Move down"),
         ("k", "cursor_up", "Move up"),
@@ -412,6 +433,21 @@ class XarrayTUI(App):
             return
 
         self.push_screen(StatisticsScreen(current_node.data["item"]))
+
+    def action_show_table(self) -> None:
+        """An action to show the selected variable's values as a table."""
+        tree = self.query_one(Tree)
+        current_node = tree.cursor_node
+        if current_node is None:
+            return
+
+        if (
+            current_node.data is None
+            or current_node.data.get("type") != "variable_node"
+        ):
+            return
+
+        self.push_screen(TableScreen(current_node.data["item"]))
 
     def action_expand_all(self) -> None:
         """An action to expand all tree nodes."""

--- a/xr_tui/plotting.py
+++ b/xr_tui/plotting.py
@@ -6,7 +6,7 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.widget import Widget
-from textual.widgets import RadioButton, RadioSet, Static
+from textual.widgets import DataTable, RadioButton, RadioSet, Static
 from textual_plotext import PlotextPlot
 from textual_slider import Slider
 
@@ -233,7 +233,7 @@ class PlotNDWidget(Widget):
         await plot_container.mount(slice_inputs)
         await plot_container.mount(new_plot)
 
-    # pylint: disable-msg=too-many-locals
+    # pylint: disable=too-many-locals
     def _plot_variable_nd(
         self, dim1: int = 0, dim2: int = 1, slice_positions: dict = None
     ) -> PlotextPlot:
@@ -299,3 +299,179 @@ class PlotNDWidget(Widget):
         )
         plot_widget.plt.title(title)
         return plot_widget
+
+
+MAX_TABLE_ROWS = 500
+MAX_TABLE_COLS = 200
+
+
+class TableNDWidget(Widget):
+    """A widget to display 1D/2D/ND variables as a navigable table."""
+
+    def __init__(self, variable: xr.DataArray, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.variable = variable
+
+    def compose(self) -> ComposeResult:
+        """Create child widgets."""
+        dims = list(self.variable.dims)
+        ndim = len(dims)
+
+        contents = [Static("", id="table-truncation-warning")]
+
+        if ndim > 2:
+            dim1, dim2 = 0, 1
+
+            r1_buttons = [
+                RadioButton(dim, value=i == dim1, disabled=i == dim2)
+                for i, dim in enumerate(dims)
+            ]
+            r2_buttons = [
+                RadioButton(dim, value=i == dim2, disabled=i == dim1)
+                for i, dim in enumerate(dims)
+            ]
+
+            r1 = RadioSet(*r1_buttons, id="row-dim-select")
+            r1.border_title = "[white]Row Dimension[/]"
+            r2 = RadioSet(*r2_buttons, id="col-dim-select")
+            r2.border_title = "[white]Column Dimension[/]"
+
+            contents.append(Horizontal(r1, r2, id="table-dim-controls"))
+            contents.append(self._create_slice_sliders(dim1, dim2))
+
+        contents.append(DataTable(id="data-table", cursor_type="cell"))
+        yield Vertical(*contents, id="table-container")
+
+    def on_mount(self) -> None:
+        """Populate the table and focus it when the widget mounts."""
+        self._populate_table()
+        self.query_one(DataTable).focus()
+
+    def _create_slice_sliders(self, dim1: int = 0, dim2: int = 1) -> Horizontal:
+        """Build a Horizontal container of Sliders for all dims except dim1/dim2."""
+        dims = list(self.variable.dims)
+        sliders = []
+        for dim in dims:
+            if dim not in [dims[dim1], dims[dim2]]:
+                size = self.variable.sizes[dim]
+                s = Slider(0, size - 1, step=1, value=size // 2, id=f"slice-{dim}", name=dim)
+                s.border_title = f"[white]Slice: {dim}[/]"
+                sliders.append(s)
+        return Horizontal(*sliders, id="table-slice-container")
+
+    def _get_selected_dim(self, radio_set: RadioSet) -> int:
+        """Return the index of the currently selected RadioButton in a RadioSet."""
+        for i, radio in enumerate(radio_set.children):
+            if isinstance(radio, RadioButton) and radio.value:
+                return i
+        return 0
+
+    @on(Slider.Changed)
+    async def on_slider_changed(self, _event: Slider.Changed) -> None:
+        """Refresh the table when a slice slider moves."""
+        self._populate_table()
+
+    async def on_radio_set_changed(self, _message: RadioSet.Changed) -> None:
+        """Update disabled states, rebuild sliders, and refresh table on axis change."""
+        dim1_group = self.query_one("#row-dim-select")
+        dim2_group = self.query_one("#col-dim-select")
+
+        dim1 = self._get_selected_dim(dim1_group)
+        dim2 = self._get_selected_dim(dim2_group)
+
+        for i, radio in enumerate(dim1_group.children):
+            if isinstance(radio, RadioButton):
+                radio.disabled = i == dim2
+
+        for i, radio in enumerate(dim2_group.children):
+            if isinstance(radio, RadioButton):
+                radio.disabled = i == dim1
+
+        dim1_group.refresh()
+        dim2_group.refresh()
+
+        new_sliders = self._create_slice_sliders(dim1, dim2)
+        await self.query_one("#table-slice-container").remove()
+        await self.query_one("#table-container").mount(
+            new_sliders, before=self.query_one(DataTable)
+        )
+
+        self._populate_table()
+
+    # pylint: disable=too-many-locals
+    def _populate_table(self) -> None:
+        table = self.query_one(DataTable)
+        table.clear(columns=True)
+
+        dims = list(self.variable.dims)
+        ndim = len(dims)
+
+        if ndim == 1:
+            dim = dims[0]
+            values = self.variable.values
+            display = min(len(values), MAX_TABLE_ROWS)
+            self._set_truncation_warning(len(values), 1, display, 1)
+            table.add_column(dim, key="index")
+            table.add_column(str(self.variable.name or "value"), key="value")
+            coord = self.variable.coords.get(dim)
+            for i in range(display):
+                row_label = format_coord_value(coord.values[i]) if coord is not None else str(i)
+                table.add_row(row_label, self._fmt(values[i]))
+            return
+
+        if ndim > 2:
+            dim1 = self._get_selected_dim(self.query_one("#row-dim-select"))
+            dim2 = self._get_selected_dim(self.query_one("#col-dim-select"))
+        else:
+            dim1, dim2 = 0, 1
+
+        row_dim = dims[dim1]
+        col_dim = dims[dim2]
+
+        slice_dict = {}
+        for i, dim in enumerate(dims):
+            if i in (dim1, dim2):
+                continue
+            slice_dict[dim] = int(self.query_one(f"#slice-{dim}", Slider).value)
+
+        sliced = self.variable.isel(slice_dict).transpose(row_dim, col_dim)
+        data_2d = sliced.values
+
+        n_rows, n_cols = data_2d.shape
+        display_rows = min(n_rows, MAX_TABLE_ROWS)
+        display_cols = min(n_cols, MAX_TABLE_COLS)
+        self._set_truncation_warning(n_rows, n_cols, display_rows, display_cols)
+
+        row_coord = self.variable.coords.get(row_dim)
+        col_coord = self.variable.coords.get(col_dim)
+
+        table.add_column(row_dim, key="row_index")
+        for j in range(display_cols):
+            label = format_coord_value(col_coord.values[j]) if col_coord is not None else str(j)
+            table.add_column(label, key=f"col_{j}")
+
+        for i in range(display_rows):
+            row_label = format_coord_value(row_coord.values[i]) if row_coord is not None else str(i)
+            table.add_row(row_label, *[self._fmt(data_2d[i, j]) for j in range(display_cols)])
+
+    def _fmt(self, val) -> str:
+        try:
+            f = float(val)
+            if np.isnan(f):
+                return "NaN"
+            if np.isinf(f):
+                return "Inf" if f > 0 else "-Inf"
+            return f"{f:.4g}"
+        except (TypeError, ValueError):
+            return str(val)
+
+    def _set_truncation_warning(
+        self, n_rows: int, n_cols: int, d_rows: int, d_cols: int
+    ) -> None:
+        w = self.query_one("#table-truncation-warning", Static)
+        if d_rows < n_rows or d_cols < n_cols:
+            w.update(
+                f"[yellow]Showing {d_rows} of {n_rows} rows × {d_cols} of {n_cols} cols[/]"
+            )
+        else:
+            w.update("")

--- a/xr_tui/xr-tui.tcss
+++ b/xr_tui/xr-tui.tcss
@@ -60,3 +60,40 @@ StatisticsScreen {
     border: thick red 80%;
     background: $surface;
 }
+
+TableScreen {
+    align: center middle;
+    background: rgba(0, 0, 0, 0);
+}
+
+#table-screen {
+    padding: 0 1;
+    width: 90%;
+    height: 90%;
+    border: thick $background 80%;
+    background: $surface;
+}
+
+#table-container {
+    height: 100%;
+    width: 100%;
+}
+
+#table-truncation-warning {
+    height: 1;
+    text-align: center;
+}
+
+#table-dim-controls {
+    height: auto;
+    max-height: 8;
+}
+
+#table-slice-container {
+    height: auto;
+    max-height: 4;
+}
+
+#data-table {
+    height: 1fr;
+}


### PR DESCRIPTION
## Summary

- Adds a new `TableScreen` modal (press `t` on any variable) that displays raw data values in a scrollable `DataTable`
- For N-D arrays (>2 dims): RadioSet axis selectors and Sliders for slicing other dimensions — same UX as the existing plot view
- Caps display at 500 rows × 200 columns with a yellow truncation warning; arrow-key cell navigation works freely within the visible window
- `NaN`, `Inf`, and `-Inf` values are rendered as strings; string/object dtype arrays display as text (no error screen)

## Test plan

- [ ] Press `t` on a 1D variable — table shows dim index + values column
- [ ] Press `t` on a 2D variable — table shows row/col coordinate labels and values
- [ ] Press `t` on an ND variable (>2 dims) — RadioSets and Sliders appear; changing them updates the displayed slice
- [ ] Press `t` on a variable with >500 rows — truncation warning appears
- [ ] Arrow keys navigate cells within the table
- [ ] Variables containing NaN or Inf display `"NaN"` / `"Inf"` / `"-Inf"` in cells
- [ ] Press `Escape` — returns to main tree view
- [ ] `ruff check .` and `pylint xr_tui` both pass (10.00/10 with package installed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzSoSSUeAdRRnoymfPYG83)_