### PR TITLE
Release prep: v0.3.0

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.2.0"
+current_version = "0.3.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ xr-tui is an interactive terminal user interface (TUI) for exploring and visuali
 - Easy-to-use command-line interface.
 - Displays dataset statistics and metadata.
 - Handles HDF5 files not formatted as xarray datasets.
+- Interactive table view of raw data values.
+- Export dataset structure as JSON without launching the TUI.
 
 ## Domain Specific Formats
 xr-tui additionally supports domain specific formats such as the HDF5 [NeXus](https://www.nexusformat.org/) format along with any custom xarray backends that supports datatrees. The list of actively supported xarray backends is as follows:
@@ -60,6 +62,13 @@ xr-tui also works with remote datasets accessible via HTTP:
 xr http://example.com/data.zarr
 ```
 
+You can export the dataset structure as JSON without launching the TUI:
+
+```bash
+xr <filename> --export-json            # print to stdout
+xr <filename> --export-json out.json   # write to file
+```
+
 ## Key Command Reference
 
 | Key | Action |
@@ -72,3 +81,4 @@ xr http://example.com/data.zarr
 | `Enter` | Select an item or open a variable |
 | `s` | Show statistics of the selected variable. |
 | `p` | Plot the selected variable. |
+| `t` | Show the selected variable as a scrollable data table. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xr-tui"
-version = "0.2.0"
+version = "0.3.0"
 requires-python = ">=3.11"
 description = "A Textual User Interface (TUI) for exploring xarray Datasets."
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- Updates README to document the two features from the recently merged PRs:
  - Table view (`t` keybinding) — new `TableScreen` modal with N-D slicing
  - `--export-json` flag — export dataset structure as JSON without launching TUI
- Bumps version `0.2.0 → 0.3.0` via `bump-my-version bump minor`

## To release after merging

1. Merge this PR
2. Go to **Releases → Draft a new release** on GitHub
3. Create tag `v0.3.0` targeting `main`, title `v0.3.0`, and publish the release
4. This triggers `publish.yml` → PyPI deployment automatically

---
_Generated by [Claude Code](https://claude.ai/code/session_011C6Knz2WFZ8Du8ZmtHTUcX)_